### PR TITLE
ci: add AWS deployment pipeline with Jenkins and SonarQube integration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,218 @@
+pipeline {
+    agent any
+
+    environment {
+        // AWS – in Jenkins Credentials konfigurieren (ID: aws-credentials)
+        AWS_DEFAULT_REGION = 'eu-central-1'
+        AWS_ACCOUNT_ID     = credentials('aws-account-id')
+        ECR_REGISTRY       = "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+
+        // Image Namen
+        BACKEND_IMAGE  = "${ECR_REGISTRY}/drinking-leaderboard-backend"
+        FRONTEND_IMAGE = "${ECR_REGISTRY}/drinking-leaderboard-frontend"
+        IMAGE_TAG      = "${env.BUILD_NUMBER}-${env.GIT_COMMIT?.take(7) ?: 'latest'}"
+
+        // EC2 Deployment – in Jenkins Credentials konfigurieren
+        EC2_HOST = credentials('ec2-host')        // z.B. "ec2-user@1.2.3.4"
+        EC2_KEY  = credentials('ec2-ssh-key')     // SSH private key
+
+        // SonarQube – Server "SonarQube" in Jenkins konfigurieren
+        SONAR_PROJECT_KEY = 'drinking-leaderboard'
+    }
+
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '10'))
+        timeout(time: 30, unit: 'MINUTES')
+        disableConcurrentBuilds()
+    }
+
+    stages {
+
+        stage('Checkout') {
+            steps {
+                checkout scm
+            }
+        }
+
+        // ─── BACKEND ────────────────────────────────────────────────────────────
+        stage('Backend – Install') {
+            steps {
+                dir('backend') {
+                    sh 'npm ci'
+                }
+            }
+        }
+
+        stage('Backend – Tests & Coverage') {
+            steps {
+                dir('backend') {
+                    sh 'npm run test:ci'
+                }
+            }
+            post {
+                always {
+                    junit allowEmptyResults: true,
+                          testResults: 'backend/coverage/junit.xml'
+                }
+            }
+        }
+
+        // ─── FRONTEND ────────────────────────────────────────────────────────────
+        stage('Frontend – Install') {
+            steps {
+                dir('frontend') {
+                    sh 'npm ci'
+                }
+            }
+        }
+
+        stage('Frontend – Tests & Coverage') {
+            steps {
+                dir('frontend') {
+                    sh 'npm run test:ci'
+                }
+            }
+            post {
+                always {
+                    junit allowEmptyResults: true,
+                          testResults: 'frontend/coverage/junit.xml'
+                }
+            }
+        }
+
+        // ─── SONARQUBE ───────────────────────────────────────────────────────────
+        stage('SonarQube Analysis') {
+            steps {
+                withSonarQubeEnv('SonarQube') {
+                    sh """
+                        sonar-scanner \
+                            -Dsonar.projectKey=${SONAR_PROJECT_KEY} \
+                            -Dsonar.projectVersion=${env.BUILD_NUMBER}
+                    """
+                }
+            }
+        }
+
+        stage('SonarQube – Quality Gate') {
+            steps {
+                timeout(time: 5, unit: 'MINUTES') {
+                    waitForQualityGate abortPipeline: true
+                }
+            }
+        }
+
+        // ─── DOCKER BUILD ────────────────────────────────────────────────────────
+        stage('Build Docker Images') {
+            when {
+                anyOf {
+                    branch 'main'
+                    branch 'master'
+                }
+            }
+            parallel {
+                stage('Build Backend') {
+                    steps {
+                        dir('backend') {
+                            sh "docker build -t ${BACKEND_IMAGE}:${IMAGE_TAG} -t ${BACKEND_IMAGE}:latest ."
+                        }
+                    }
+                }
+                stage('Build Frontend') {
+                    steps {
+                        dir('frontend') {
+                            sh "docker build -t ${FRONTEND_IMAGE}:${IMAGE_TAG} -t ${FRONTEND_IMAGE}:latest ."
+                        }
+                    }
+                }
+            }
+        }
+
+        // ─── AWS ECR PUSH ────────────────────────────────────────────────────────
+        stage('Push to AWS ECR') {
+            when {
+                anyOf {
+                    branch 'main'
+                    branch 'master'
+                }
+            }
+            steps {
+                withCredentials([[$class: 'AmazonWebServicesCredentialsBinding',
+                                  credentialsId: 'aws-credentials']]) {
+                    sh """
+                        aws ecr get-login-password --region ${AWS_DEFAULT_REGION} \
+                            | docker login --username AWS --password-stdin ${ECR_REGISTRY}
+
+                        docker push ${BACKEND_IMAGE}:${IMAGE_TAG}
+                        docker push ${BACKEND_IMAGE}:latest
+
+                        docker push ${FRONTEND_IMAGE}:${IMAGE_TAG}
+                        docker push ${FRONTEND_IMAGE}:latest
+                    """
+                }
+            }
+        }
+
+        // ─── DEPLOY TO EC2 ───────────────────────────────────────────────────────
+        stage('Deploy to AWS EC2') {
+            when {
+                anyOf {
+                    branch 'main'
+                    branch 'master'
+                }
+            }
+            steps {
+                withCredentials([[$class: 'AmazonWebServicesCredentialsBinding',
+                                  credentialsId: 'aws-credentials'],
+                                 sshUserPrivateKey(credentialsId: 'ec2-ssh-key',
+                                                  keyFileVariable: 'SSH_KEY')]) {
+                    sh """
+                        ssh -i ${SSH_KEY} -o StrictHostKeyChecking=no ${EC2_HOST} << 'REMOTE'
+                            aws ecr get-login-password --region ${AWS_DEFAULT_REGION} \
+                                | docker login --username AWS --password-stdin ${ECR_REGISTRY}
+
+                            docker pull ${BACKEND_IMAGE}:latest
+                            docker pull ${FRONTEND_IMAGE}:latest
+
+                            cd /opt/drinking-leaderboard
+                            BACKEND_IMAGE=${BACKEND_IMAGE}:latest \
+                            FRONTEND_IMAGE=${FRONTEND_IMAGE}:latest \
+                            docker compose -f docker-compose.prod.yml up -d --remove-orphans
+
+                            docker image prune -f
+                        REMOTE
+                    """
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            // Coverage Reports im Jenkins UI anzeigen
+            publishHTML(target: [
+                allowMissing: true,
+                alwaysLinkToLastBuild: true,
+                keepAll: true,
+                reportDir: 'backend/coverage/lcov-report',
+                reportFiles: 'index.html',
+                reportName: 'Backend Coverage'
+            ])
+            publishHTML(target: [
+                allowMissing: true,
+                alwaysLinkToLastBuild: true,
+                keepAll: true,
+                reportDir: 'frontend/coverage/lcov-report',
+                reportFiles: 'index.html',
+                reportName: 'Frontend Coverage'
+            ])
+            // Lokale Docker Images aufräumen
+            sh 'docker image prune -f || true'
+        }
+        success {
+            echo "Deployment erfolgreich: ${BACKEND_IMAGE}:${IMAGE_TAG}"
+        }
+        failure {
+            echo 'Pipeline fehlgeschlagen – bitte Logs prüfen.'
+        }
+    }
+}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY --from=builder /app/dist ./dist
+EXPOSE 4000
+CMD ["node", "dist/server.js"]

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
     '!src/db/connection.ts',
   ],
   coverageDirectory: 'coverage',
+  coverageReporters: ['lcov', 'text', 'clover'],
   coverageThreshold: {
     global: {
       branches: 70,

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "start": "node dist/server.js"
+    "start": "node dist/server.js",
+    "test": "jest --coverage",
+    "test:ci": "jest --ci --coverage"
   },
   "dependencies": {
     "express": "^4.21.2",
@@ -15,8 +17,11 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.12",
     "@types/node": "^20.11.19",
     "@types/pg": "^8.11.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.4",
     "typescript": "^5.3.3"
   }
 }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,35 @@
+services:
+  backend:
+    image: ${BACKEND_IMAGE:-drinking-leaderboard-backend:latest}
+    restart: unless-stopped
+    ports:
+      - "4000:4000"
+    environment:
+      NODE_ENV: production
+      PORT: 4000
+      # Alle DB-Variablen via .env.prod auf der EC2-Instanz bereitstellen
+      DATABASE_URL: ${DATABASE_URL}
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:4000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+
+  frontend:
+    image: ${FRONTEND_IMAGE:-drinking-leaderboard-frontend:latest}
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      NODE_ENV: production
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://backend:4000}
+    depends_on:
+      backend:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/public ./public
+EXPOSE 3000
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+CMD ["node", "server.js"]

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -15,6 +15,7 @@ const customJestConfig = {
     '!**/*.test.js',
   ],
   coverageDirectory: 'coverage',
+  coverageReporters: ['lcov', 'text', 'clover'],
   coverageThreshold: {
     global: {
       branches: 70,

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  /* config options here */
+  output: 'standalone',
 };
 
 export default nextConfig;

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,18 @@
+sonar.projectKey=drinking-leaderboard
+sonar.projectName=Drinking Leaderboard
+sonar.projectVersion=1.0
+
+# Sources
+sonar.sources=backend/src,frontend/app,frontend/components
+sonar.tests=backend/src,frontend/app,frontend/components
+sonar.test.inclusions=**/*.test.ts,**/*.test.js
+
+# Exclusions
+sonar.exclusions=**/node_modules/**,**/.next/**,**/dist/**,**/coverage/**,**/public/**,**/*.d.ts
+
+# Coverage reports (lcov format from Jest)
+sonar.javascript.lcov.reportPaths=backend/coverage/lcov.info,frontend/coverage/lcov.info
+sonar.typescript.lcov.reportPaths=backend/coverage/lcov.info
+
+# Language
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
- Add Dockerfiles for backend (multi-stage, Node 20 Alpine) and frontend (Next.js standalone output for minimal image size)
- Add Jenkinsfile with full declarative pipeline: install → test → SonarQube quality gate → ECR push → EC2 deploy
- Add sonar-project.properties pointing Jest lcov reports for both services
- Add docker-compose.prod.yml for EC2 container orchestration
- Enable next.config.mjs output: standalone (required for frontend Dockerfile)
- Add jest/ts-jest devDependencies and test:ci script to backend package.json
- Set explicit lcov coverageReporters in both jest configs so SonarQube can pick up coverage data